### PR TITLE
Fix fold colors

### DIFF
--- a/lua/seoul256/theme.lua
+++ b/lua/seoul256/theme.lua
@@ -104,7 +104,7 @@ theme.loadEditor = function ()
 		DiffText =				{ fg = seoul256.yellow, bg = seoul256.none, style = 'reverse' }, -- diff mode: Changed text within a changed line
 		EndOfBuffer =			{ fg = seoul256.disabled },
 		ErrorMsg =				{ fg = seoul256.none },
-		Folded =				{ fg = seoul256.disabled, bg = seoul256.none, style = 'italic' },
+		Folded =				{ fg = seoul256.green, bg = seoul256.bg_alt, style = 'italic' },
 		FoldColumn =			{ fg = seoul256.blue },
 		IncSearch =				{ fg = seoul256.highlight, bg = seoul256.white, style = 'reverse' },
 		LineNr =				{ fg = seoul256.line_numbers },


### PR DESCRIPTION
Closed folds were previously unreadable. This pr changes the foreground and background of Folded.
note: please don't mind the example file used

Before:

![image](https://user-images.githubusercontent.com/65604882/121927256-67b75a00-cd71-11eb-926e-feb6ea859069.png)


After:

![image](https://user-images.githubusercontent.com/65604882/121927422-98978f00-cd71-11eb-9504-832d841b9a93.png)


What do you guys think? Is it good enough or do you know of any better colors to use?