### PR TITLE
master: adding cursor colors

### DIFF
--- a/lua/seoul256/theme.lua
+++ b/lua/seoul256/theme.lua
@@ -154,7 +154,7 @@ M.treesitter = {
     TSRepeat = { fg = colors.purple },
     TSStrike = {}, -- TODO
     TSString = { fg = colors.string },
-    TSStringEscape = { fg = colors.disabled },
+    TSStringEscape = { fg = colors.fg },
     TSStringRegex = { fg = colors.blue },
     TSStringSpecial = {}, -- TODO
     TSStrong = {}, -- TODO

--- a/lua/seoul256/theme.lua
+++ b/lua/seoul256/theme.lua
@@ -92,8 +92,8 @@ M.editor = {
     TabLineFill = { fg = colors.fg },
     Tabline = { fg = colors.fg },
     TablineSel = { fg = colors.bg, bg = colors.accent },
-    TermCursor = { fg = colors.cursor, bg = colors.none, style = "reverse" }, -- TODO
-    TermCursorNC = { fg = colors.cursor, bg = colors.none, style = "reverse" }, -- TODO
+    TermCursor = { fg = colors.cursor, bg = colors.none, style = "reverse" },
+    TermCursorNC = { fg = colors.cursor, bg = colors.none, style = "reverse" },
     Title = { fg = colors.green, bg = colors.none, style = "bold" },
     VertSplit = { fg = colors.bg },
     Visual = { fg = colors.none, bg = colors.selection },

--- a/lua/seoul256/theme.lua
+++ b/lua/seoul256/theme.lua
@@ -92,8 +92,8 @@ M.editor = {
     TabLineFill = { fg = colors.fg },
     Tabline = { fg = colors.fg },
     TablineSel = { fg = colors.bg, bg = colors.accent },
-    TermCursor = {}, -- TODO
-    TermCursorNC = {}, -- TODO
+    TermCursor = { fg = colors.cursor, bg = colors.none, style = "reverse" }, -- TODO
+    TermCursorNC = { fg = colors.cursor, bg = colors.none, style = "reverse" }, -- TODO
     Title = { fg = colors.green, bg = colors.none, style = "bold" },
     VertSplit = { fg = colors.bg },
     Visual = { fg = colors.none, bg = colors.selection },

--- a/lua/seoul256/theme.lua
+++ b/lua/seoul256/theme.lua
@@ -18,7 +18,7 @@ M.syntax = {
     Float = { fg = colors.orange },
     Function = { fg = colors.blue },
     Identifier = { fg = colors.pink },
-    Ignore = { fg = colors.disabled },
+    Ignore = { fg = colors.fg },
     Include = { fg = colors.blue },
     Keyword = { fg = colors.purple },
     Label = { fg = colors.purple },
@@ -46,7 +46,7 @@ M.syntax = {
 -- Type `:h highlight-groups` for more informations
 M.editor = {
     ColorColumn = { fg = colors.none, bg = colors.active },
-    Conceal = { fg = colors.disabled },
+    Conceal = { fg = colors.fg },
     Cursor = { fg = colors.cursor, bg = colors.none, style = "reverse" },
     lCursor = {}, -- TODO
     CursorColumn = { fg = colors.none, bg = colors.active },
@@ -58,7 +58,7 @@ M.editor = {
     DiffDelete = { fg = colors.red, bg = colors.none, style = "reverse" },
     DiffText = { fg = colors.yellow, bg = colors.none, style = "reverse" },
     Directory = { fg = colors.blue, bg = colors.none },
-    EndOfBuffer = { fg = colors.disabled },
+    EndOfBuffer = { fg = colors.fg },
     ErrorMsg = { fg = colors.none },
     FoldColumn = { fg = colors.blue },
     Folded = { fg = colors.green, bg = colors.bg_alt, style = "italic" },
@@ -69,7 +69,7 @@ M.editor = {
     MoreMsg = { fg = colors.accent },
     MsgArea = {}, -- TODO
     MsgSeparator = {}, -- TODO
-    NonText = { fg = colors.disabled },
+    NonText = { fg = colors.fg },
     Normal = { fg = colors.fg, bg = colors.bg },
     NormalFloat = { fg = colors.fg, bg = colors.float },
     NormalNC = {}, -- TODO
@@ -87,7 +87,7 @@ M.editor = {
     SpellLocal = { fg = colors.cyan, bg = colors.none, style = "undercurl,italic" },
     SpellRare = { fg = colors.purple, bg = colors.none, style = "undercurl,italic" },
     StatusLine = { fg = colors.fg, bg = colors.bg_alt },
-    StatusLineNC = { fg = colors.text, bg = colors.disabled },
+    StatusLineNC = { fg = colors.text, bg = colors.fg },
     Substitute = {}, -- TODO
     TabLineFill = { fg = colors.fg },
     Tabline = { fg = colors.fg },
@@ -268,9 +268,9 @@ M.plugins = {
         NvimTreeExecFile = { fg = colors.green },
         NvimTreeSpecialFile = { fg = colors.purple, style = "underline" },
         NvimTreeFolderName = { fg = colors.paleblue },
-        NvimTreeEmptyFolderName = { fg = colors.disabled },
+        NvimTreeEmptyFolderName = { fg = colors.fg },
         NvimTreeFolderIcon = { fg = colors.accent },
-        NvimTreeIndentMarker = { fg = colors.disabled },
+        NvimTreeIndentMarker = { fg = colors.fg },
 
         -- TODO not sure this goes here
         LspDiagnosticsError = { fg = colors.error },


### PR DESCRIPTION
Changes allow cursor display when navigating the terminal in native `vi` mode
![cursor_displayed_term_vi_mode](https://user-images.githubusercontent.com/15057271/175434917-4addeac6-2a32-452a-a982-7fcc815998e7.png)
![cursor_displayed_term_normal_mode](https://user-images.githubusercontent.com/15057271/175434920-e7e69a21-a3c1-4595-9a9b-6252fa4ce216.png)
.