### PR TITLE
fix #15: missing highlight groups for indent-blankline.nvim

### DIFF
--- a/lua/seoul256/theme.lua
+++ b/lua/seoul256/theme.lua
@@ -99,7 +99,7 @@ M.editor = {
     Visual = { fg = colors.none, bg = colors.selection },
     VisualNOS = { fg = colors.none, bg = colors.selection },
     WarningMsg = { fg = colors.yellow },
-    Whitespace = {}, -- TODO
+    Whitespace = { fg = colors.text },
     WildMenu = { fg = colors.orange, bg = colors.none, style = "bold" },
 
     -- GUI only
@@ -325,6 +325,8 @@ M.plugins = {
     IndentBlankline = {
         IndentBlanklineChar = { fg = colors.indentline },
         IndentBlanklineContextChar = { fg = colors.indentline },
+        IblIndent = { fg = colors.indentline },
+        IblScope = { fg = colors.highlight },
     },
 
     NvimDap = {


### PR DESCRIPTION
This should address the errors in #15 . Wasn't sure which color to use for `IblScope` so I just eyeballed it based on the README picture.